### PR TITLE
Check args count before trying to access them

### DIFF
--- a/main.cu
+++ b/main.cu
@@ -26,7 +26,10 @@ int main(int ac, char **av)
     std::clock_t start;
     int x;
 
-
+    if (ac < 2) {
+        cout << "Usage : alenka [--QPS-test] | [ [-l load size(MB)] [-v] script.sql ]" << endl;
+        exit(1);
+    }
     // test QPS via alenkaExecute	-- this section is the only C++ dependency
     if (string(av[1]) == "--QPS-test") {
         alenkaInit(NULL);
@@ -38,12 +41,7 @@ int main(int ac, char **av)
         alenkaClose();
     }
     else {				// ordinary alenka file mode
-        if (ac < 2) {
-            cout << "Usage : alenka [--QPS-test] | [ [-l load size(MB)] [-v] script.sql ]" << endl;
-            exit(1);
-        }
-        else
-            return execute_file( ac, av) ;
+        return execute_file( ac, av) ;
     }
 }
 


### PR DESCRIPTION
Otherwise this happens:
```bash
λ ~/Alenka/ master* ./alenka
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_S_construct null not valid
[1]    3870 abort (core dumped)  ./alenka
```